### PR TITLE
switch travis to openjdk8 (from oraclejdk8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 # This is for https://travis-ci.org/ - you can ignore it.
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
fixes #6 

copy of https://github.com/javaparser/javaparser-maven-sample/pull/8 but for this repo